### PR TITLE
Revert back to main pg14 source

### DIFF
--- a/install/Brewfile
+++ b/install/Brewfile
@@ -10,7 +10,6 @@ tap "lotyp/homebrew-formulae"
 # Tap petere postgresql to install multiple postgres versions
 #    Link: https://medium.com/keeping-code/running-multiple-postgresql-versions-simultaneously-on-macos-linux-90b3d7e08ffd
 tap "petere/postgresql"
-tap "thimble-consulting/homebrew-postgresql"
 
 brew "direnv"
 
@@ -40,7 +39,7 @@ brew "the_silver_searcher" # search via ag <search-term>
 
 # Postgres
 brew "petere/postgresql/postgresql-common"
-brew "thimble-consulting/homebrew-postgresql/postgresql@14"
+brew "petere/postgresql/postgresql@14"
 brew "petere/postgresql/postgresql@17"
 
 # Redis


### PR DESCRIPTION
Installing Postgres 14 ran into issues on both my and Ruairi's computers.

The root cause seems to be that it depends on an outdated version of openssl. I saw that someone else reported this issue on the repo where the formula comes from: https://github.com/petere/homebrew-postgresql/issues/67

I proposed an update to the formula on this PR on the main repo: https://github.com/petere/homebrew-postgresql/issues/67

In the interim, our installation uses a fork of the main repo, where I made these changes. This works fine - but if/when this gets onto the main repo, we could shut down our fork and revert back to the main source.

## TODO:

- [x] Check if [the PR](https://github.com/petere/homebrew-postgresql/issues/67) has been accepted (or if the main repo has solved this in another way)
- [x] Archive [our fork](https://github.com/thimble-consulting/homebrew-postgresql)
- [x] Merge this in!